### PR TITLE
Update _textfields.scss

### DIFF
--- a/src/components/_textfields.scss
+++ b/src/components/_textfields.scss
@@ -61,7 +61,7 @@
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
-    caret-color: rgb($p);
+    caret-color: rgb($green);
     transition: border-bottom 0.2s, background-color 0.2s;
 }
 .textfield.filled > input + span,
@@ -89,7 +89,7 @@
     display: block;
     width: 100%;
     height: 2px;
-    background-color: rgb($p);
+    background-color: rgb($green);
     transform-origin: bottom center;
     transform: scaleX(0);
     transition: transform 0.3s;
@@ -110,7 +110,7 @@
 }
 .textfield.filled > input:focus + span,
 .textfield.filled > textarea:focus + span {
-    color: rgb($p);
+    color: rgb($green);
 }
 .textfield.filled > input:focus + span::after,
 .textfield.filled > textarea:focus + span::after {
@@ -163,7 +163,7 @@
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
-    caret-color: $p;
+    caret-color: $green;
     transition: border 0.2s, box-shadow 0.2s;
 }
 .textfield.outlined > input:not(:focus):placeholder-shown,
@@ -239,26 +239,26 @@
 }
 .textfield.outlined > input:focus,
 .textfield.outlined > textarea:focus {
-    border-color: transparent $p $p;
-    box-shadow: inset 1px 0 $p, inset -1px 0 $p, inset 0 -1px $p;
+    border-color: transparent $green $green;
+    box-shadow: inset 1px 0 $green, inset -1px 0 $green, inset 0 -1px $green;
     outline: none;
 }
 .textfield.outlined > input:focus + span,
 .textfield.outlined > textarea:focus + span {
-    color: $p;
+    color: $green;
 }
 .textfield.outlined > input:focus + span::before,
 .textfield.outlined > input:focus + span::after,
 .textfield.outlined > textarea:focus + span::before,
 .textfield.outlined > textarea:focus + span::after {
-    border-top-color: $p;
-    box-shadow: inset 0 1px $p;
+    border-top-color: $green;
+    box-shadow: inset 0 1px $green;
 }
 .textfield.outlined > input:disabled,
 .textfield.outlined > input:disabled + span,
 .textfield.outlined > textarea:disabled,
 .textfield.outlined > textarea:disabled + span {
-    border-color: transparent $p $p !important;
+    border-color: transparent $green $green !important;
     color: rgba(0, 0, 0, 0.38);
     pointer-events: none;
 }
@@ -266,13 +266,13 @@
 .textfield.outlined > input:disabled + span::after,
 .textfield.outlined > textarea:disabled + span::before,
 .textfield.outlined > textarea:disabled + span::after {
-    border-top-color: $p !important;
+    border-top-color: $green !important;
 }
 .textfield.outlined > input:disabled:placeholder-shown,
 .textfield.outlined > input:disabled:placeholder-shown + span,
 .textfield.outlined > textarea:disabled:placeholder-shown,
 .textfield.outlined > textarea:disabled:placeholder-shown + span {
-    border-top-color: $p !important;
+    border-top-color: $green !important;
 }
 .textfield.outlined > input:disabled:placeholder-shown + span::before,
 .textfield.outlined > input:disabled:placeholder-shown + span::after,
@@ -318,7 +318,7 @@
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
-    caret-color: $p;
+    caret-color: $green;
     transition: border-bottom 0.2s, background-color 0.2s;
 }
 .textfield.border-bottom > input + span,
@@ -346,7 +346,7 @@
     display: block;
     width: 100%;
     height: 2px;
-    background-color: $p;
+    background-color: $green;
     transform-origin: bottom center;
     transform: scaleX(0);
     transition: transform 0.2s;
@@ -366,7 +366,7 @@
 }
 .textfield.border-bottom > input:focus + span,
 .textfield.border-bottom > textarea:focus + span {
-    color: $p;
+    color: $green;
 }
 .textfield.border-bottom > input:focus + span::after,
 .textfield.border-bottom > textarea:focus + span::after {


### PR DESCRIPTION
i have made this because of this error on build:
```
Error: Missing element $green.
   ╷
64 │     caret-color: rgb($p);
   │                  ^^^^^^^
   ╵
  src/components/_textfields.scss 64:18  @import
  src/src.scss 93:9                      root stylesheet
    at Object._newRenderError (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:13190:19)
    at Object._wrapException (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:13018:16)
    at StaticClosure._renderSync (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:12996:18)
    at Object.Primitives_applyFunction (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:1130:30)
    at Object.Function_apply (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:5897:16)
    at _callDartFunctionFast (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:7599:16)
    at Object.renderSync (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/node_modules/sass/sass.dart.js:7577:18)
    at build_CSS (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/index.js:122:28)
    at Object.<anonymous> (/home/runner/work/_actions/gha-utilities/sass-build/v0.4.3/index.js:167:5)
    at Module._compile (internal/modules/cjs/loader.js:959:30) {
  formatted: 'Error: Missing element $green.\n' +
    '   ╷\n' +
    '64 │     caret-color: rgb($p);\r\n' +
    '   │                  ^^^^^^^\n' +
    '   ╵\n' +
    '  src/components/_textfields.scss 64:18  @import\n' +
    '  src/src.scss 93:9                      root stylesheet',
  line: 64,
  column: 18,
  file: '/home/runner/work/material/material/src/components/_textfields.scss',
  status: 1
```